### PR TITLE
Add ability to pass `ChromeOptions` to the `ChromeDriver`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ jsEnv := new org.scalajs.jsenv.selenium.SeleniumJSEnv(BROWSER)
 // Apply to tests
 jsEnv in Test := new org.scalajs.jsenv.selenium.SeleniumJSEnv(BROWSER)
 ```
-where the `BROWSER` can be either `org.scalajs.jsenv.selenium.Firefox` or
-`org.scalajs.jsenv.selenium.Chrome`.
+where the `BROWSER` can be either `org.scalajs.jsenv.selenium.Firefox()` or
+`org.scalajs.jsenv.selenium.Chrome()`.
 
 When executing the program with `run` a new browser window will be created,
 the code will be executed in it and finally the browser will close itself.

--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ lazy val seleniumJSEnvTest: Project = project.
   enablePlugins(ScalaJSJUnitPlugin).
   settings(testSettings).
   settings(
-    jsEnv := new SeleniumJSEnv(Firefox)
+    jsEnv := new SeleniumJSEnv(Firefox())
   )
 
 lazy val seleniumJSHttpEnvTest: Project = project.
@@ -126,6 +126,6 @@ lazy val seleniumJSHttpEnvTest: Project = project.
   enablePlugins(ScalaJSJUnitPlugin).
   settings(testSettings).
   settings(
-    jsEnv := new SeleniumJSEnv(Firefox).
+    jsEnv := new SeleniumJSEnv(Firefox()).
       withMaterializer(new CustomFileMaterializer("tmp", "http://localhost:8080/tmp"))
   )

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -7,6 +7,16 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.SeleniumBrowser.setupConsoleCapture"),
       ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.BrowserDriver.newConsoleLogsIterator"),
       ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Firefox#FirefoxDriver.newConsoleLogsIterator"),
-      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Chrome#ChromeDriver.newConsoleLogsIterator")
+      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Chrome#ChromeDriver.newConsoleLogsIterator"),
+      ProblemFilters.exclude[MissingTypesProblem]("org.scalajs.jsenv.selenium.Chrome$"),
+      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Chrome.newDriver"),
+      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Chrome.initFiles"),
+      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Chrome.name"),
+      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Chrome#ChromeDriver.this"),
+      ProblemFilters.exclude[MissingTypesProblem]("org.scalajs.jsenv.selenium.Firefox$"),
+      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Firefox.newDriver"),
+      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Firefox.initFiles"),
+      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Firefox.name"),
+      ProblemFilters.exclude[MissingMethodProblem]("org.scalajs.jsenv.selenium.Firefox#FirefoxDriver.this")
   )
 }

--- a/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/Chrome.scala
+++ b/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/Chrome.scala
@@ -1,23 +1,33 @@
 package org.scalajs.jsenv.selenium
 
-import org.openqa.selenium.chrome.ChromeDriverService
+import org.openqa.selenium.chrome.{ChromeDriverService, ChromeOptions}
 import org.openqa.selenium.remote._
 
-object Chrome extends SeleniumBrowser {
+import scala.language.implicitConversions
+
+object Chrome {
+  def apply(): Chrome = new Chrome(new ChromeOptions)
+
+  @deprecated("Use Chrome() instead.", "0.1.3")
+  implicit def useAsConfig(self: Chrome.type): Chrome = apply()
+}
+
+class Chrome private (chromeOptions: ChromeOptions) extends SeleniumBrowser {
+
   def name: String = "Chrome"
 
   def newDriver: BrowserDriver = new ChromeDriver
+  def withChromeOptions(chromeOptions: ChromeOptions): Chrome = new Chrome(chromeOptions)
 
   private class ChromeDriver extends BrowserDriver {
     protected def newDriver(): RemoteWebDriver = {
-      val caps = DesiredCapabilities.chrome()
       val service = {
         /* Activate the silent ChromeDriverService silent mode,
          * see ChromeDriverService.createDefaultService
          */
         new ChromeDriverService.Builder().withSilent(true).usingAnyFreePort.build
       }
-      new org.openqa.selenium.chrome.ChromeDriver(service, caps)
+      new org.openqa.selenium.chrome.ChromeDriver(service, chromeOptions)
     }
   }
 }

--- a/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/Firefox.scala
+++ b/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/Firefox.scala
@@ -2,7 +2,16 @@ package org.scalajs.jsenv.selenium
 
 import org.openqa.selenium.remote.RemoteWebDriver
 
-object Firefox extends SeleniumBrowser {
+import scala.language.implicitConversions
+
+object Firefox {
+  def apply(): Firefox = new Firefox
+
+  @deprecated("Use Firefox() instead.", "0.1.3")
+  implicit def useAsConfig(self: Firefox.type): Firefox = apply()
+}
+
+class Firefox private () extends SeleniumBrowser {
   def name: String = "Firefox"
 
   def newDriver: BrowserDriver = new FirefoxDriver


### PR DESCRIPTION
I'm running tests in a Docker container
(https://hub.docker.com/r/gshakhn/sbt-firefox-chromium/).
Chrome and Docker don't play well together unless you pass
`--no-sandbox` to Chrome (elgalu/docker-selenium#9)
This change lets me set pass in `ChromeOptions` with the custom argument
to Chrome.

This is a breaking change since `Chrome` is now a class instead of an
object. Update readme to reflect that.

Other than the above, this should be backwards compatible.
The overloaded constructor of `ChromeDriver` just calls
`options.toCapabilities`, which has the old `DesiredCapabilities.chrome`
code.
