### PR TITLE
Upgrade selenium to 3.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
     seleniumJSHttpEnvTest/test
   - >
     sbt ++$TRAVIS_SCALA_VERSION
-    'set jsEnvCapabilities in seleniumJSEnvTest := org.openqa.selenium.remote.DesiredCapabilities.chrome()'
+    'set jsEnvCapabilities in seleniumJSEnvTest := new org.openqa.selenium.chrome.ChromeOptions()'
     seleniumJSEnvTest/run
     seleniumJSEnvTest/test
     'set scalaJSStage in Global := FullOptStage'
@@ -58,7 +58,7 @@ script:
     seleniumJSEnvTest/test
   - >
     sbt ++$TRAVIS_SCALA_VERSION
-    'set jsEnvCapabilities in seleniumJSHttpEnvTest := org.openqa.selenium.remote.DesiredCapabilities.chrome()'
+    'set jsEnvCapabilities in seleniumJSHttpEnvTest := new org.openqa.selenium.chrome.ChromeOptions()'
     seleniumJSHttpEnvTest/test
     'set scalaJSStage in Global := FullOptStage'
     seleniumJSHttpEnvTest/test

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For example for Firefox:
 
 ```scala
 jsEnv := new org.scalajs.jsenv.selenium.SeleniumJSEnv(
-    org.openqa.selenium.remote.DesiredCapabilities.firefox())
+    new org.openqa.selenium.firefox.FirefoxOptions())
 ```
 
 You are responsible for installing the [drivers](

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ import sbt.Keys._
 import org.scalajs.sbtplugin.ScalaJSCrossVersion
 
 import org.openqa.selenium.Capabilities
-import org.openqa.selenium.remote.DesiredCapabilities
 
 import org.scalajs.jsenv.selenium.SeleniumJSEnv
 
@@ -65,7 +64,7 @@ val jsEnvCapabilities = settingKey[org.openqa.selenium.Capabilities](
     "Capabilities of the SeleniumJSEnv")
 
 val testSettings: Seq[Setting[_]] = commonSettings ++ Seq(
-  jsEnvCapabilities := DesiredCapabilities.firefox(),
+  jsEnvCapabilities := new org.openqa.selenium.firefox.FirefoxOptions(),
   jsEnv := new SeleniumJSEnv(jsEnvCapabilities.value),
   jsDependencies ++= Seq(
       RuntimeDOM % "test",
@@ -86,7 +85,7 @@ lazy val seleniumJSEnv: Project = project.
          * It pulls in "closure-compiler-java-6" which in turn bundles some old
          * guava stuff which in turn makes selenium fail.
          */
-        "org.seleniumhq.selenium" % "selenium-server" % "3.4.0",
+        "org.seleniumhq.selenium" % "selenium-server" % "3.13.0",
         "org.scala-js" %% "scalajs-js-envs" % scalaJSVersion,
         "org.scala-js" %% "scalajs-js-envs-test-kit" % scalaJSVersion % "test",
         "com.novocode" % "junit-interface" % "0.11" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import org.scalajs.jsenv.selenium.SeleniumJSEnv
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import com.typesafe.tools.mima.plugin.MimaKeys.{previousArtifact, binaryIssueFilters}
 
-val previousVersion = Some("0.2.0")
+val previousVersion = None
 
 val scalaVersionsUsedForPublishing: Set[String] =
   Set("2.10.6", "2.11.11", "2.12.2")
@@ -18,7 +18,7 @@ val newScalaBinaryVersionsInThisRelease: Set[String] =
   Set()
 
 val commonSettings: Seq[Setting[_]] = Seq(
-  version := "0.2.1-SNAPSHOT",
+  version := "0.3.0-SNAPSHOT",
   organization := "org.scala-js",
   scalaVersion := "2.11.11",
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
  * guava stuff which in turn makes selenium fail.
  */
 libraryDependencies ~=
-  ("org.seleniumhq.selenium" % "selenium-server" % "3.4.0" +: _)
+  ("org.seleniumhq.selenium" % "selenium-server" % "3.13.0" +: _)
 
 unmanagedSourceDirectories in Compile ++= {
   val root = baseDirectory.value.getParentFile

--- a/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumJSEnv.scala
+++ b/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumJSEnv.scala
@@ -70,7 +70,7 @@ object SeleniumJSEnv {
     private def this() = this(
         keepAlive = false,
         materialization = Config.Materialization.Temp,
-        driverFactory = Config.defaultFactory)
+        driverFactory = new DefaultDriverFactory(Platform.getCurrent()))
 
     /** Materializes purely virtual files into a temp directory.
      *
@@ -99,7 +99,7 @@ object SeleniumJSEnv {
      *  {{{
      *  jsSettings(
      *    jsEnv := new SeleniumJSEnv(
-     *        org.openqa.selenium.remote.DesiredCapabilities.firefox(),
+     *        new org.openqa.selenium.firefox.FirefoxOptions(),
      *        SeleniumJSEnv.Config()
      *          .withMaterializeInServer(".tmp", "http://localhost:8080/")
      *    )
@@ -149,26 +149,6 @@ object SeleniumJSEnv {
   }
 
   object Config {
-    private val defaultFactory = {
-      val factory = new DefaultDriverFactory()
-
-      def r(caps: Capabilities, clazz: Class[_ <: WebDriver]) =
-        factory.registerDriverProvider(new DefaultDriverProvider(caps, clazz))
-
-      import org.openqa.{selenium => s}
-
-      r(DesiredCapabilities.firefox(), classOf[s.firefox.FirefoxDriver])
-      r(DesiredCapabilities.chrome(), classOf[s.chrome.ChromeDriver])
-      r(DesiredCapabilities.internetExplorer(), classOf[s.ie.InternetExplorerDriver])
-      r(DesiredCapabilities.edge(), classOf[s.edge.EdgeDriver])
-      r(DesiredCapabilities.operaBlink(), classOf[s.opera.OperaDriver])
-      r(DesiredCapabilities.safari(), classOf[s.safari.SafariDriver])
-      r(DesiredCapabilities.phantomjs(), classOf[s.phantomjs.PhantomJSDriver])
-      r(DesiredCapabilities.htmlUnit(), classOf[s.htmlunit.HtmlUnitDriver])
-
-      factory
-    }
-
     def apply(): Config = new Config()
 
     abstract class Materialization private ()

--- a/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/SeleniumJSEnvTest.scala
+++ b/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/SeleniumJSEnvTest.scala
@@ -1,6 +1,5 @@
 package org.scalajs.jsenv.selenium
 
-import org.openqa.selenium.remote.DesiredCapabilities
 import org.scalajs.jsenv.test._
 import org.junit._
 
@@ -60,11 +59,13 @@ abstract class SeleniumJSEnvTest extends TimeoutComTests {
 }
 
 class SeleniumJSEnvChromeTest extends SeleniumJSEnvTest {
-  protected def newJSEnv: SeleniumJSEnv =
-    new SeleniumJSEnv(DesiredCapabilities.chrome())
+  import org.openqa.selenium.chrome.ChromeOptions
+
+  protected def newJSEnv: SeleniumJSEnv = new SeleniumJSEnv(new ChromeOptions())
 }
 
 class SeleniumJSEnvFirefoxTest extends SeleniumJSEnvTest {
-  protected def newJSEnv: SeleniumJSEnv =
-    new SeleniumJSEnv(DesiredCapabilities.firefox())
+  import org.openqa.selenium.firefox.FirefoxOptions
+
+  protected def newJSEnv: SeleniumJSEnv = new SeleniumJSEnv(new FirefoxOptions())
 }


### PR DESCRIPTION
This brings the major change that the DefaultDriverFactory now actually creates the default drivers for things. So we do not need to register it ourselves anymore.

We also use browser specific option objects instead of the factories on DesiredCapabilities (log messages told us to do so).