### PR TITLE
Improve config API for materialization

### DIFF
--- a/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/AbstractSeleniumJSRunner.scala
+++ b/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/AbstractSeleniumJSRunner.scala
@@ -60,9 +60,10 @@ private[selenium] abstract class AbstractSeleniumJSRunner(
     setupCapture() ++ runtimeEnv()
 
   protected def runAllScripts(): Unit = {
+    val materializer = config.newMaterializer
     val jsFiles = initFiles() ++ libs.map(_.lib) :+ code
-    val page = htmlPage(jsFiles.map(config.materializer.materialize _))
-    val pageURL = config.materializer.materialize(page)
+    val page = htmlPage(jsFiles.map(materializer.materialize _))
+    val pageURL = materializer.materialize(page)
 
     /* driver needs to be synchronized on.
      * endRun() might have been called while we were doing the work above.


### PR DESCRIPTION
The old API (which we retain for backwards compatibility) was leaking a type that was private[selenium]. We define a new API based on an ADT instead (note that we do not guarantee that we won't add new values).