### PR TITLE
Migrate to Selenium 4, add Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10
         with:
-          java-version: "adopt@1.8"
+          java-version: "adopt@1.11"
       - uses: coursier/cache-action@v5
       - name: Scalastyle
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaversion: ["2.11.12", "2.12.10", "2.13.1"]
+        scalaversion: ["2.12.20", "2.13.15"]
         browser: ["chrome"]
         include:
-          - scalaversion: "2.12.10"
+          - scalaversion: "2.12.20"
             browser: "firefox"
     env:
       SJS_TEST_BROWSER: ${{ matrix.browser }}
@@ -29,10 +29,10 @@ jobs:
         run: >
           sbt "++${{ matrix.scalaversion }}"
           seleniumJSEnv/scalastyle
-          seleniumJSEnv/test:scalastyle
+          seleniumJSEnv/Test/scalastyle
           seleniumJSEnvTest/scalastyle
-          seleniumJSHttpEnvTest/test:scalastyle
-          seleniumJSEnvTest/test:scalastyle
+          seleniumJSHttpEnvTest/Test/scalastyle
+          seleniumJSEnvTest/Test/scalastyle
       - name: MiMa
         run: sbt "++${{ matrix.scalaversion }}" seleniumJSEnv/mimaReportBinaryIssues
       - name: Unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaversion: ["2.12.20", "2.13.15"]
-        browser: ["chrome"]
+        scalaversion: [ "2.12.20", "2.13.16" ]
+        browser: [ "chrome" ]
         include:
           - scalaversion: "2.12.20"
             browser: "firefox"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,10 @@ jobs:
       SJS_TEST_BROWSER: ${{ matrix.browser }}
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v14
+      - uses: coursier/setup-action@v1
         with:
-          java-version: "adopt@1.11"
+          jvm: "temurin:11"
+          apps: sbt
       - uses: coursier/cache-action@v6
       - name: Scalastyle
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,10 +22,10 @@ jobs:
       SJS_TEST_BROWSER: ${{ matrix.browser }}
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-scala@v14
         with:
           java-version: "adopt@1.11"
-      - uses: coursier/cache-action@v5
+      - uses: coursier/cache-action@v6
       - name: Scalastyle
         run: >
           sbt "++${{ matrix.scalaversion }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaversion: [ "2.12.20", "2.13.16" ]
+        scalaversion: [ "2.12.21", "2.13.18" ]
         browser: [ "chrome" ]
         include:
-          - scalaversion: "2.12.20"
+          - scalaversion: "2.12.21"
             browser: "firefox"
     env:
       SJS_TEST_BROWSER: ${{ matrix.browser }}

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val newScalaBinaryVersionsInThisRelease: Set[String] =
   Set()
 
 val commonSettings: Seq[Setting[_]] = Seq(
-  version := "1.1.2-SNAPSHOT",
+  version := "2.0.0-SNAPSHOT",
   organization := "org.scala-js",
   scalaVersion := "2.12.20",
   crossScalaVersions := Seq("2.12.20", "2.13.15"),

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ val newScalaBinaryVersionsInThisRelease: Set[String] =
 val commonSettings: Seq[Setting[_]] = Seq(
   version := "1.1.2-SNAPSHOT",
   organization := "org.scala-js",
-  scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1"),
+  scalaVersion := "2.12.20",
+  crossScalaVersions := Seq("2.12.20", "2.13.15"),
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
 
   homepage := Some(url("http://scala-js.org/")),
@@ -117,7 +117,7 @@ lazy val seleniumJSEnv: Project = project.
     pomIncludeRepository := { _ => false },
 
     // The chrome driver seems to not deal with parallelism very well (#47).
-    parallelExecution in Test := false
+    (Test / parallelExecution) := false
   )
 
 lazy val seleniumJSEnvTest: Project = project.

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,10 @@ import org.scalajs.sbtplugin.ScalaJSCrossVersion
 import org.openqa.selenium.Capabilities
 
 import org.scalajs.jsenv.selenium.SeleniumJSEnv
-import org.scalajs.jsenv.selenium.TestCapabilities
+import org.scalajs.jsenv.selenium.TestDrivers
 
-val previousVersion: Option[String] = Some("1.1.1")
+// we're breaking bincompat with the bump to selenium 4
+val previousVersion: Option[String] = None
 
 val newScalaBinaryVersionsInThisRelease: Set[String] =
   Set()
@@ -55,12 +56,8 @@ val previousArtifactSetting = Def.settings(
   }
 )
 
-val jsEnvCapabilities = settingKey[org.openqa.selenium.Capabilities](
-    "Capabilities of the SeleniumJSEnv")
-
 val testSettings: Seq[Setting[_]] = commonSettings ++ Seq(
-  jsEnvCapabilities := TestCapabilities.fromEnv,
-  jsEnv := new SeleniumJSEnv(jsEnvCapabilities.value),
+  jsEnv := new SeleniumJSEnv(TestDrivers.fromEnv),
   scalaJSUseMainModuleInitializer := true
 )
 
@@ -77,7 +74,7 @@ lazy val seleniumJSEnv: Project = project.
          * It pulls in "closure-compiler-java-6" which in turn bundles some old
          * guava stuff which in turn makes selenium fail.
          */
-        "org.seleniumhq.selenium" % "selenium-server" % "3.141.59",
+        "org.seleniumhq.selenium" % "selenium-java" % "4.25.0",
         "org.scala-js" %% "scalajs-js-envs" % "1.1.1",
         "com.google.jimfs" % "jimfs" % "1.1",
         "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.1.1" % "test",
@@ -132,7 +129,7 @@ lazy val seleniumJSHttpEnvTest: Project = project.
   settings(
     jsEnv := {
       new SeleniumJSEnv(
-          jsEnvCapabilities.value,
+          TestDrivers.fromEnv,
           SeleniumJSEnv.Config()
             .withMaterializeInServer("tmp", "http://localhost:8080/tmp/")
       )

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val seleniumJSEnv: Project = project.
          */
         "org.seleniumhq.selenium" % "selenium-java" % "4.35.0",
         "org.scala-js" %% "scalajs-js-envs" % "1.4.0",
-        "com.google.jimfs" % "jimfs" % "1.1",
+        "com.google.jimfs" % "jimfs" % "1.3.1",
         "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.4.0" % Test,
         "com.novocode" % "junit-interface" % "0.11" % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val commonSettings: Seq[Setting[_]] = Seq(
   version := "2.0.0-SNAPSHOT",
   organization := "org.scala-js",
   scalaVersion := crossScalaVersions.value.head,
-  crossScalaVersions := Seq("2.12.20", "2.13.16"),
+  crossScalaVersions := Seq("2.12.21", "2.13.18"),
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
 
   homepage := Some(url("http://scala-js.org/")),
@@ -60,10 +60,10 @@ lazy val seleniumJSEnv: Project = project.
          * It pulls in "closure-compiler-java-6" which in turn bundles some old
          * guava stuff which in turn makes selenium fail.
          */
-        "org.seleniumhq.selenium" % "selenium-java" % "4.35.0",
-        "org.scala-js" %% "scalajs-js-envs" % "1.4.0",
+        "org.seleniumhq.selenium" % "selenium-java" % "4.43.0",
+        "org.scala-js" %% "scalajs-js-envs" % "1.6.0",
         "com.google.jimfs" % "jimfs" % "1.3.1",
-        "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.4.0" % Test,
+        "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.6.0" % Test,
         "com.novocode" % "junit-interface" % "0.11" % Test
     ),
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,12 +7,6 @@ import org.openqa.selenium.Capabilities
 import org.scalajs.jsenv.selenium.SeleniumJSEnv
 import org.scalajs.jsenv.selenium.TestDrivers
 
-// we're breaking bincompat with the bump to selenium 4
-val previousVersion: Option[String] = None
-
-val newScalaBinaryVersionsInThisRelease: Set[String] =
-  Set()
-
 val commonSettings: Seq[Setting[_]] = Seq(
   version := "2.0.0-SNAPSHOT",
   organization := "org.scala-js",
@@ -30,29 +24,20 @@ val commonSettings: Seq[Setting[_]] = Seq(
   testOptions += Tests.Argument(TestFramework("com.novocode.junit.JUnitFramework"), "-v", "-a")
 )
 
-val previousArtifactSetting = Def.settings(
-  mimaPreviousArtifacts ++= {
-    val scalaV = scalaVersion.value
-    val scalaBinaryV = scalaBinaryVersion.value
-    val thisProjectID = projectID.value
-    previousVersion match {
-      case None =>
-        Set.empty
-      case _ if newScalaBinaryVersionsInThisRelease.contains(scalaBinaryV) =>
-        // New in this release, no binary compatibility to comply to
-        Set.empty
-      case Some(prevVersion) =>
-        /* Filter out e:info.apiURL as it expects 0.6.7-SNAPSHOT, whereas the
-         * artifact we're looking for has 0.6.6 (for example).
-         */
-        val prevExtraAttributes =
-          thisProjectID.extraAttributes.filterKeys(_ != "e:info.apiURL")
-        val prevProjectID =
-          (thisProjectID.organization % thisProjectID.name % prevVersion)
-            .cross(thisProjectID.crossVersion)
-            .extra(prevExtraAttributes.toSeq: _*)
-        Set(prevProjectID)
-    }
+val mimaSettings = Seq(
+  mimaBinaryIssueFilters ++= BinaryIncompatibilities.SeleniumJSEnv,
+  mimaFailOnNoPrevious := false,
+  mimaPreviousArtifacts := {
+    // Released versions - will be Set("2.0.0", "2.0.1", etc.) after releases
+    val all: Set[String] = Set.empty
+
+    // Exclusion predicates per Scala binary version
+    // Example: Map("3" -> (_.startsWith("2.0."))) would exclude 2.0.x versions for Scala 3
+    val exclusions: Map[String, String => Boolean] = Map.empty
+
+    all
+      .filterNot(exclusions.getOrElse(scalaBinaryVersion.value, _ => false))
+      .map(v => organization.value %% name.value % v)
   }
 )
 
@@ -66,6 +51,7 @@ name := "root"
 
 lazy val seleniumJSEnv: Project = project.
   settings(commonSettings).
+  settings(mimaSettings).
   settings(
     name := "scalajs-env-selenium",
 
@@ -80,9 +66,6 @@ lazy val seleniumJSEnv: Project = project.
         "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.1.1" % "test",
         "com.novocode" % "junit-interface" % "0.11" % "test"
     ),
-
-    previousArtifactSetting,
-    mimaBinaryIssueFilters ++= BinaryIncompatibilities.SeleniumJSEnv,
 
     publishMavenStyle := true,
     publishTo := {

--- a/build.sbt
+++ b/build.sbt
@@ -61,10 +61,10 @@ lazy val seleniumJSEnv: Project = project.
          * guava stuff which in turn makes selenium fail.
          */
         "org.seleniumhq.selenium" % "selenium-java" % "4.35.0",
-        "org.scala-js" %% "scalajs-js-envs" % "1.1.1",
+        "org.scala-js" %% "scalajs-js-envs" % "1.4.0",
         "com.google.jimfs" % "jimfs" % "1.1",
-        "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.1.1" % "test",
-        "com.novocode" % "junit-interface" % "0.11" % "test"
+        "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.4.0" % Test,
+        "com.novocode" % "junit-interface" % "0.11" % Test
     ),
 
     publishMavenStyle := true,

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val seleniumJSEnv: Project = project.
          * It pulls in "closure-compiler-java-6" which in turn bundles some old
          * guava stuff which in turn makes selenium fail.
          */
-        "org.seleniumhq.selenium" % "selenium-java" % "4.25.0",
+        "org.seleniumhq.selenium" % "selenium-java" % "4.35.0",
         "org.scala-js" %% "scalajs-js-envs" % "1.1.1",
         "com.google.jimfs" % "jimfs" % "1.1",
         "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.1.1" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ import org.scalajs.jsenv.selenium.TestDrivers
 val commonSettings: Seq[Setting[_]] = Seq(
   version := "2.0.0-SNAPSHOT",
   organization := "org.scala-js",
-  scalaVersion := "2.12.20",
-  crossScalaVersions := Seq("2.12.20", "2.13.15"),
+  scalaVersion := crossScalaVersions.value.head,
+  crossScalaVersions := Seq("2.12.20", "2.13.16"),
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
 
   homepage := Some(url("http://scala-js.org/")),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.10.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.2
+sbt.version=1.11.5

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.5
+sbt.version=1.12.11

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
  * guava stuff which in turn makes selenium fail.
  */
 libraryDependencies ~=
-  ("org.seleniumhq.selenium" % "selenium-server" % "3.141.59" +: _)
+  ("org.seleniumhq.selenium" % "selenium-java" % "4.25.0" +: _)
 
 Compile / unmanagedSourceDirectories ++= {
   val root = baseDirectory.value.getParentFile
@@ -18,5 +18,5 @@ Compile / unmanagedSourceDirectories ++= {
 
 Compile / sources += {
   val root = baseDirectory.value.getParentFile
-  root / "seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/TestCapabilities.scala"
+  root / "seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/TestDrivers.scala"
 }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.2.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 
@@ -11,12 +11,12 @@ addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 libraryDependencies ~=
   ("org.seleniumhq.selenium" % "selenium-server" % "3.141.59" +: _)
 
-unmanagedSourceDirectories in Compile ++= {
+Compile / unmanagedSourceDirectories ++= {
   val root = baseDirectory.value.getParentFile
   Seq(root / "seleniumJSEnv/src/main/scala")
 }
 
-sources in Compile += {
+Compile / sources += {
   val root = baseDirectory.value.getParentFile
   root / "seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/TestCapabilities.scala"
 }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.21.0")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 
@@ -9,7 +9,7 @@ addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
  * guava stuff which in turn makes selenium fail.
  */
 libraryDependencies ~=
-  ("org.seleniumhq.selenium" % "selenium-java" % "4.35.0" +: _)
+  ("org.seleniumhq.selenium" % "selenium-java" % "4.43.0" +: _)
 
 Compile / unmanagedSourceDirectories ++= {
   val root = baseDirectory.value.getParentFile

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
  * guava stuff which in turn makes selenium fail.
  */
 libraryDependencies ~=
-  ("org.seleniumhq.selenium" % "selenium-java" % "4.25.0" +: _)
+  ("org.seleniumhq.selenium" % "selenium-java" % "4.35.0" +: _)
 
 Compile / unmanagedSourceDirectories ++= {
   val root = baseDirectory.value.getParentFile

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.1")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
 

--- a/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumJSEnv.scala
+++ b/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumJSEnv.scala
@@ -14,6 +14,8 @@ import SeleniumJSEnv.DriverFactory
 
 final class SeleniumJSEnv(driverFactory: DriverFactory, config: SeleniumJSEnv.Config) extends JSEnv {
 
+  def this(driverFactory: DriverFactory) = this(driverFactory, SeleniumJSEnv.Config())
+
   val name: String = s"SeleniumJSEnv ($config)"
 
   def start(input: Seq[Input], runConfig: RunConfig): JSRun =
@@ -38,8 +40,6 @@ final class SeleniumJSEnv(driverFactory: DriverFactory, config: SeleniumJSEnv.Co
 
     driver.asInstanceOf[WebDriver with JavascriptExecutor]
   }
-
-  def this(driverFactory: DriverFactory) = this(driverFactory, SeleniumJSEnv.Config())
 }
 
 object SeleniumJSEnv {

--- a/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumJSEnv.scala
+++ b/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumJSEnv.scala
@@ -3,6 +3,7 @@ package org.scalajs.jsenv.selenium
 
 import org.scalajs.jsenv._
 
+import java.net.URI
 import java.net.URL
 import java.nio.file.{Path, Paths}
 import org.openqa.selenium.Capabilities
@@ -90,7 +91,7 @@ object SeleniumJSEnv {
      *  }}}
      */
     def withMaterializeInServer(contentDir: String, webRoot: String): Config =
-      withMaterializeInServer(Paths.get(contentDir), new URL(webRoot))
+      withMaterializeInServer(Paths.get(contentDir), URI.create(webRoot).toURL)
 
     /** Materializes files in a static directory of a user configured server.
      *

--- a/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumRun.scala
+++ b/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumRun.scala
@@ -166,9 +166,10 @@ private[selenium] object SeleniumRun {
 
   private def htmlPage(fullInput: Seq[Input], materializer: FileMaterializer): String = {
     val tags = fullInput.map {
-      case Input.Script(path)   => makeTag(path, "text/javascript", materializer)
-      case Input.ESModule(path) => makeTag(path, "module", materializer)
-      case _                    => throw new UnsupportedInputException(fullInput)
+      case Input.Script(path)         => makeTag(path, "text/javascript", materializer)
+      case Input.ESModule(path)       => makeTag(path, "module", materializer)
+      case Input.CommonJSModule(path) => makeTag(path, "text/javascript", materializer)
+      case _                          => throw new UnsupportedInputException(fullInput)
     }
 
     s"""<html>

--- a/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumRun.scala
+++ b/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumRun.scala
@@ -130,6 +130,7 @@ private[selenium] object SeleniumRun {
       config: Config, runConfig: RunConfig, enableCom: Boolean)(
       newRun: Ctor[T], failed: Throwable => T): T = {
     validator.validate(runConfig)
+    validateInput(input)
 
     try {
       withCleanup(FileMaterializer(config.materialization))(_.close()) { m =>
@@ -163,6 +164,13 @@ private[selenium] object SeleniumRun {
 
   private def maybeCleanupDriver(d: WebDriver, config: SeleniumJSEnv.Config) =
     if (!config.keepAlive) d.quit()
+
+  private def validateInput(input: Seq[Input]): Unit = {
+    input.foreach {
+      case _: Input.Script | _: Input.ESModule | _: Input.CommonJSModule => // ok
+      case _ => throw new UnsupportedInputException(input)
+    }
+  }
 
   private def htmlPage(fullInput: Seq[Input], materializer: FileMaterializer): String = {
     val tags = fullInput.map {

--- a/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumRun.scala
+++ b/seleniumJSEnv/src/main/scala/org/scalajs/jsenv/selenium/SeleniumRun.scala
@@ -24,7 +24,7 @@ private sealed class SeleniumRun(
 
   protected val intf = "this.scalajsSeleniumInternalInterface"
 
-  private[this] implicit val ec =
+  private[this] implicit val ec: ExecutionContextExecutor =
     ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
 
   private val handler = Future {

--- a/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/KeepAliveTest.scala
+++ b/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/KeepAliveTest.scala
@@ -7,12 +7,12 @@ import java.net.URL
 
 import org.openqa.selenium._
 import org.openqa.selenium.remote.DesiredCapabilities
-import org.openqa.selenium.remote.server._
 
 import org.junit._
 import org.junit.Assert._
 
 import org.scalajs.jsenv._
+import org.scalajs.jsenv.selenium.SeleniumJSEnv.DriverFactory
 
 class KeepAliveTest {
   private final class MockWebDriver extends WebDriver with JavascriptExecutor {
@@ -56,23 +56,19 @@ class KeepAliveTest {
   private final class MockInjector(driver: WebDriver) extends DriverFactory {
     var used = false
 
-    def newInstance(caps: Capabilities): WebDriver = {
+    def apply(): WebDriver = {
       require(!used)
       used = true
       driver
     }
-
-    def hasMappingFor(caps: Capabilities): Boolean = true
-    def registerDriverProvider(p: DriverProvider): Unit = ???
   }
 
   private def setup(keepAlive: Boolean) = {
     val driver = new MockWebDriver
     val factory = new MockInjector(driver)
     val config = SeleniumJSEnv.Config()
-      .withDriverFactory(factory)
       .withKeepAlive(keepAlive)
-    val env = new SeleniumJSEnv(new DesiredCapabilities, config)
+    val env = new SeleniumJSEnv(factory, config)
 
     (driver, factory, env)
   }

--- a/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/SeleniumJSSuite.scala
+++ b/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/SeleniumJSSuite.scala
@@ -9,8 +9,10 @@ import org.junit.runner.Runner
 import org.junit.runners.Suite
 import org.junit.runner.manipulation.Filter
 import org.junit.runner.Description
+import org.openqa.selenium.firefox.FirefoxDriver
+import org.openqa.selenium.firefox.FirefoxOptions
 
 @RunWith(classOf[JSEnvSuiteRunner])
 class SeleniumJSSuite extends JSEnvSuite(
-  JSEnvSuiteConfig(new SeleniumJSEnv(TestCapabilities.fromEnv))
+  JSEnvSuiteConfig(new SeleniumJSEnv(TestDrivers.fromEnv))
 )

--- a/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/TestDrivers.scala
+++ b/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/TestDrivers.scala
@@ -5,20 +5,28 @@ import org.openqa.selenium.firefox.{FirefoxOptions, FirefoxDriverLogLevel}
 import org.openqa.selenium.chrome.ChromeOptions
 
 import java.util.logging.{Logger, Level}
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.firefox.FirefoxDriver
+import org.openqa.selenium.chrome.ChromeDriver
+import org.scalajs.jsenv.selenium.SeleniumJSEnv.DriverFactory
 
-object TestCapabilities {
+object TestDrivers {
   // Lower the logging level for Selenium to avoid spam.
   Logger.getLogger("org.openqa.selenium").setLevel(Level.WARNING)
 
-  def fromEnv: Capabilities = nameFromEnv match {
+  val fromEnv: DriverFactory = () => nameFromEnv match {
     case "firefox" =>
-      new FirefoxOptions()
-        .setHeadless(true)
-        .setLogLevel(FirefoxDriverLogLevel.ERROR)
+      new FirefoxDriver(
+        new FirefoxOptions()
+          .addArguments("--headless")
+          .setLogLevel(FirefoxDriverLogLevel.ERROR)
+      )
 
     case "chrome" =>
-      new ChromeOptions()
-        .setHeadless(true)
+      new ChromeDriver(
+        new ChromeOptions()
+          .addArguments("--headless")
+      )
 
     case name =>
       throw new IllegalArgumentException(s"Unknown browser $name")

--- a/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/TestDrivers.scala
+++ b/seleniumJSEnv/src/test/scala/org/scalajs/jsenv/selenium/TestDrivers.scala
@@ -25,7 +25,12 @@ object TestDrivers {
     case "chrome" =>
       new ChromeDriver(
         new ChromeOptions()
-          .addArguments("--headless")
+          .addArguments(
+            "--headless=new",
+            "--no-sandbox",
+            "--disable-dev-shm-usage",
+            "--allow-file-access-from-files"
+          )
       )
 
     case name =>


### PR DESCRIPTION
- Drops Scala 2.11 (more recent Scala.js versions don't support it)
- Updates sbt and its plugins, as well as Scala patch versions, to allow building on modern hardware (apple silicon wasn't supported well in older releases)
- `DriverFactory` from Selenium isn't a thing so we make our own
- Requires Java 11 because Selenium does as well
- A `DriverFactory` has to be provided explicitly by the user.